### PR TITLE
watch & compile index with babel into tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /npm-debug.log
+/.tmp/index.js

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-console.log('Hello jscoderetreat!');
+export function main() {
+	return 0;
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Learning TDD",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon -q -x 'babel-node index.js'",
-    "test": "nodemon -q -x 'ava test.js'"
+    "start": "babel -qwo .tmp/index.js index.js",
+    "test": "nodemon -q -w .tmp/index.js -w test.js -x 'ava test.js'"
   },
   "contributors": [
     {

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 import test from 'ava';
 
-import 'babel-core/register';
-
-import './index';
+import { main } from './.tmp/index';
 
 test('noop', t => {
     t.fail('not implemented');


### PR DESCRIPTION
compile index.js into .tmp/index.js with babel and watch .tmp/index.js
with nodemon to restart the test-runner on file changes.

BREAKING CHANGE:
in order to use this new setup, we need to `import './tmp/index.js'`
from within the test.js file.
